### PR TITLE
Added quotes to variables in the ipv6=false tree

### DIFF
--- a/dyndns-update.sh
+++ b/dyndns-update.sh
@@ -35,7 +35,7 @@ if [ $enable_ipv6 = true -a -n "$ipv6" ]; then
     curl --user $username:$password ${dyndns_update_url}myip=${ipv4}&myipv6=${ipv6}
   fi
 else
-  if [ $host_ipv4 != $ipv4 ]; then
+  if [ "$host_ipv4" != "$ipv4" ]; then
     curl --user $username:$password ${dyndns_update_url}myip=${ipv4}
   fi
 fi


### PR DESCRIPTION
I was getting the error message "unirary operator expected" and quotes solved this problem.
I followed:
https://stackoverflow.com/questions/22179405/bash-script-error-unary-operator-expected

Maybe it would be useful to add quotes around the other variables too? I personally only care about IPv4 and it works now, so I haven't tested anything else. Also I don't really know that much about bash tbh